### PR TITLE
fix(io): stop fabricating data at four reader/writer boundaries

### DIFF
--- a/src/molpy/io/data/gro.py
+++ b/src/molpy/io/data/gro.py
@@ -55,8 +55,10 @@ class GroReader(DataReader):
         molpy_frame = frames[0]  # already a canonical rich Frame from molrs.io
 
         atoms = molpy_frame["atoms"]
-        if "number" not in atoms and "id" in atoms:
-            atoms["number"] = atoms["id"].astype(np.int64, copy=False)
+        # NOTE: this reader used to set ``atoms["number"] = atoms["id"]``, i.e.
+        # it wrote the atom *serial* into the atomic-*number* column. A GRO file
+        # carries no element information, so there is nothing to derive an
+        # atomic number from — the column is simply absent.
         if "xyz" not in atoms and "x" in atoms and "y" in atoms and "z" in atoms:
             atoms["xyz"] = np.column_stack([atoms["x"], atoms["y"], atoms["z"]])
         return molpy_frame

--- a/src/molpy/io/data/lammps.py
+++ b/src/molpy/io/data/lammps.py
@@ -482,27 +482,44 @@ class LammpsDataReader(DataReader[LammpsDataResult]):
             StringIO(csv_string), delimiter=" ", skipinitialspace=True
         )
 
-        # Add mass information. atom_style="body" already carries per-atom
-        # mass in the atoms section; do not overwrite it from the (absent)
-        # Masses section. Other styles look mass up by atom type, falling
-        # back to 1.0 when the file has no Masses section.
-        if block.nrows > 0 and "mass" not in block:
-            mass_values = []
-            for type_str in block["type"]:
-                mass_values.append(masses.get(str(type_str), 1.0))
-            block["mass"] = np.array(mass_values)
+        # Add mass information. atom_style="body" already carries per-atom mass
+        # in the atoms section; do not overwrite it from the (absent) Masses
+        # section. Other styles look mass up by atom type. This used to fall
+        # back to `masses.get(type, 1.0)`, so a frame could carry an invented
+        # mass while looking complete — corrupting every dynamics and every
+        # mass-weighted quantity derived from it. There is no default mass:
+        #
+        #   no Masses section at all -> no `mass` column (a LAMMPS data file
+        #       may legitimately leave mass to the input script; an absent
+        #       optional column is the honest representation of "not stated")
+        #   Masses present but missing a type -> the file is internally
+        #       inconsistent, so fail loudly
+        if block.nrows > 0 and "mass" not in block and masses:
+            unknown = sorted({str(t) for t in block["type"] if str(t) not in masses})
+            if unknown:
+                raise ValueError(
+                    f"LAMMPS data file {self._path.name!r} has a Masses section "
+                    f"with no entry for atom type(s) {unknown}. Every type used "
+                    f"in Atoms must appear in Masses; molpy will not substitute "
+                    f"a default mass."
+                )
+            block["mass"] = np.array([masses[str(t)] for t in block["type"]])
 
-            # Convert numeric types back to string types using type labels
-            if type_labels:
-                converted_types = []
-                for type_id in block["type"]:
-                    try:
-                        type_id_int = int(type_id)
-                        converted_type = type_labels.get(type_id_int, str(type_id))
-                        converted_types.append(converted_type)
-                    except (ValueError, TypeError):
-                        converted_types.append(str(type_id))
-                block["type"] = np.array(converted_types)
+        # Convert numeric types back to string type labels. This was nested
+        # inside the mass branch above, so a file that supplied its own `mass`
+        # column (atom_style="body") — or, now, one with no Masses section —
+        # silently kept numeric types. Label resolution has nothing to do with
+        # mass; it runs whenever labels were parsed.
+        if block.nrows > 0 and type_labels:
+            converted_types = []
+            for type_id in block["type"]:
+                try:
+                    type_id_int = int(type_id)
+                    converted_type = type_labels.get(type_id_int, str(type_id))
+                    converted_types.append(converted_type)
+                except (ValueError, TypeError):
+                    converted_types.append(str(type_id))
+            block["type"] = np.array(converted_types)
 
         return block
 

--- a/src/molpy/io/data/top.py
+++ b/src/molpy/io/data/top.py
@@ -17,6 +17,37 @@ from molrs import Element
 from .base import DataReader, DataWriter, PathLike
 
 
+class TopFormatError(Exception):
+    """A ``.top`` file is structurally parseable but semantically invalid.
+
+    Deliberately **not** a :class:`ValueError`: the per-line parsers treat
+    ``ValueError`` as "this line is not a record, skip it", so a malformed
+    *record* raised as ``ValueError`` would be silently dropped instead of
+    reported.
+    """
+
+
+def _to_row_index(field: str) -> int:
+    """Convert a GROMACS 1-based atom serial to a 0-based ``atoms`` row index.
+
+    GROMACS numbers atoms from 1; canonical endpoint columns (``atomi``,
+    ``atomj``, …) are 0-based row indices into the ``atoms`` block. Storing the
+    file value unchanged shifts every endpoint by one and makes the last atom
+    index out of range — a corruption that is invisible unless a topology
+    happens to reference the final atom.
+
+    Raises:
+        TopFormatError: If *field* is not a positive integer, i.e. not a valid
+            GROMACS serial. Never silently clamps or wraps to a negative index.
+    """
+    serial = int(field)
+    if serial < 1:
+        raise TopFormatError(
+            f"GROMACS atom serial must be >= 1 (1-based), got {serial}"
+        )
+    return serial - 1
+
+
 class TopReader(DataReader):
     """Read GROMACS topology files and create Frame objects.
 
@@ -183,8 +214,8 @@ class TopReader(DataReader):
 
         try:
             return {
-                "atomi": int(parts[0]),
-                "atomj": int(parts[1]),
+                "atomi": _to_row_index(parts[0]),
+                "atomj": _to_row_index(parts[1]),
                 "type": int(parts[2]),
             }
         except (ValueError, IndexError):
@@ -213,8 +244,8 @@ class TopReader(DataReader):
 
         try:
             return {
-                "atomi": int(parts[0]),
-                "atomj": int(parts[1]),
+                "atomi": _to_row_index(parts[0]),
+                "atomj": _to_row_index(parts[1]),
                 "type": int(parts[2]),
             }
         except (ValueError, IndexError):
@@ -243,9 +274,9 @@ class TopReader(DataReader):
 
         try:
             return {
-                "atomi": int(parts[0]),
-                "atomj": int(parts[1]),
-                "atomk": int(parts[2]),
+                "atomi": _to_row_index(parts[0]),
+                "atomj": _to_row_index(parts[1]),
+                "atomk": _to_row_index(parts[2]),
                 "type": int(parts[3]),
             }
         except (ValueError, IndexError):
@@ -274,10 +305,10 @@ class TopReader(DataReader):
 
         try:
             return {
-                "atomi": int(parts[0]),
-                "atomj": int(parts[1]),
-                "atomk": int(parts[2]),
-                "atoml": int(parts[3]),
+                "atomi": _to_row_index(parts[0]),
+                "atomj": _to_row_index(parts[1]),
+                "atomk": _to_row_index(parts[2]),
+                "atoml": _to_row_index(parts[3]),
                 "type": int(parts[4]),
             }
         except (ValueError, IndexError):
@@ -463,19 +494,35 @@ class TopWriter(DataWriter):
         # [ atoms ]
         if "atoms" in frame:
             atoms = frame["atoms"]
+            # Force-field data must come from the frame. Fabricating a type
+            # ("X"), a charge (0.0) or a mass (0.0) produces a topology that
+            # loads and runs while being physically meaningless — strictly
+            # worse than refusing to write it.
+            missing = [c for c in ("type", "charge", "mass") if c not in atoms]
+            if missing:
+                raise ValueError(
+                    f"Cannot write {self._file.name}: the 'atoms' block is missing "
+                    f"required column(s) {missing}. GROMACS [ atoms ] records carry "
+                    f"force-field data that molpy will not invent; typify or assign "
+                    f"these columns before writing."
+                )
             lines.append("[ atoms ]")
             lines.append(";  nr  type  resnr  residu  atom  cgnr  charge  mass")
             n_atoms = atoms.nrows
             for i in range(n_atoms):
                 row = atoms[i]
+                atype = str(row["type"])
+                charge = float(row["charge"])
+                mass = float(row["mass"])
+                # Positional/structural serials, not measurements: GROMACS
+                # defines `nr` and `cgnr` as 1-based ordinals, and a single
+                # [ moleculetype ] block is one residue by construction. These
+                # are format conventions, so deriving them is not fabrication.
                 aid = int(row.get("id", i + 1))
-                atype = str(row.get("type", "X"))
                 resnr = int(row.get("resnr", 1))
                 residu = str(row.get("residu", mol_name))
                 name = str(row.get("name", atype))
                 cgnr = int(row.get("cgnr", i + 1))
-                charge = float(row.get("charge", 0.0))
-                mass = float(row.get("mass", 0.0))
                 lines.append(
                     f"  {aid}  {atype}  {resnr}  {residu}  {name}  "
                     f"{cgnr}  {charge:.4f}  {mass:.3f}"
@@ -494,7 +541,13 @@ class TopWriter(DataWriter):
             lines.append(f"; {header}")
             for i in range(block.nrows):
                 row = block[i]
-                vals = "  ".join(str(int(row[c])) for c in columns)
+                # Endpoints are 0-based row indices in the frame; GROMACS
+                # serials are 1-based. Mirror of `_to_row_index` on read.
+                vals = "  ".join(str(int(row[c]) + 1) for c in columns)
+                # `funct` is the GROMACS interaction-function selector, not a
+                # molpy field. Frames from other formats carry no equivalent,
+                # so 1 (the GROMACS default) is retained here rather than
+                # refusing to write. Revisited when `type`/`type_id` split.
                 funct = int(row.get("type", 1))
                 lines.append(f"  {vals}  {funct}")
             lines.append("")

--- a/tests/test_io/test_data/test_gro.py
+++ b/tests/test_io/test_data/test_gro.py
@@ -11,6 +11,24 @@ import molpy as mp
 class TestGMXGroReader:
     """Basic GRO reading tests."""
 
+    def test_atomic_number_is_not_the_atom_serial(self, TEST_DATA_DIR):
+        """A GRO file carries no element data, so it yields no atomic numbers.
+
+        The reader used to do ``atoms["number"] = atoms["id"]``, writing the
+        atom *serial* into the atomic-*number* column. Every consumer treating
+        `number` as Z then read 1, 2, 3, … as hydrogen, helium, lithium.
+        """
+        fpath = TEST_DATA_DIR / "gro/cod_4020641.gro"
+        if not fpath.exists():
+            pytest.skip("gro test data not available")
+        atoms = mp.io.read_gro(fpath, frame=molrs.Frame())["atoms"]
+
+        if "number" not in atoms:
+            return  # nothing claimed, nothing to be wrong
+        assert not np.array_equal(
+            np.asarray(atoms["number"]), np.asarray(atoms["id"])
+        ), "'number' is a copy of 'id' — atom serials mislabelled as atomic numbers"
+
     def test_gro(self, TEST_DATA_DIR):
         fpath = TEST_DATA_DIR / "gro/cod_4020641.gro"
         if not fpath.exists():
@@ -26,7 +44,6 @@ class TestGMXGroReader:
         assert str(first_atom["res_id"]) == "1"
         assert str(first_atom["res_name"]) == "LIG"
         assert str(first_atom["name"]) == "S"
-        assert int(first_atom["number"]) == 1
         xyz = np.asarray(first_atom["xyz"])
         expected_xyz = np.array([0.310, 0.862, 1.316])
         np.testing.assert_allclose(xyz, expected_xyz, rtol=1e-3)
@@ -78,7 +95,6 @@ class TestGROReaderComprehensive:
         assert "res_id" in atoms
         assert "res_name" in atoms
         assert "name" in atoms
-        assert "number" in atoms
         assert "xyz" in atoms
 
         # Check first atom data
@@ -86,7 +102,6 @@ class TestGROReaderComprehensive:
         assert "res_id" in first_atom
         assert "res_name" in first_atom
         assert "name" in first_atom
-        assert "number" in first_atom
 
         # Check coordinates
         xyz = np.asarray(first_atom["xyz"])

--- a/tests/test_io/test_data/test_lammps_data.py
+++ b/tests/test_io/test_data/test_lammps_data.py
@@ -498,6 +498,38 @@ class TestErrorHandling:
         assert frame.box is not None
         np.testing.assert_array_almost_equal(frame.box.lengths, [25.0, 30.0, 35.0])
 
+    def test_missing_mass_entry_raises(self, tmp_path):
+        """An atom type absent from Masses is an error, not a 1.0.
+
+        The reader used to fall back to ``masses.get(type, 1.0)``. The frame
+        then looked complete while carrying an invented mass, which silently
+        corrupts every dynamics and every mass-weighted quantity derived
+        from it.
+        """
+        content = """# LAMMPS data file
+2 atoms
+2 atom types
+
+0.0 10.0 xlo xhi
+0.0 10.0 ylo yhi
+0.0 10.0 zlo zhi
+
+Masses
+
+1 12.011
+
+Atoms
+
+1 1 0.0 0.0 0.0
+2 2 1.0 0.0 0.0
+"""
+        tmp_file = tmp_path / "missing_mass.data"
+        tmp_file.write_text(content)
+
+        reader = LammpsDataReader(tmp_file, atom_style="atomic")
+        with pytest.raises(ValueError, match="Masses"):
+            reader.read()
+
     def test_malformed_header(self, tmp_path):
         """Test reading file with malformed header."""
         malformed_content = """# LAMMPS data file

--- a/tests/test_io/test_data/test_top_data.py
+++ b/tests/test_io/test_data/test_top_data.py
@@ -9,7 +9,7 @@ import molrs
 from molrs import MetaValue
 
 import molpy as mp
-from molpy.io.data.top import TopReader, TopWriter
+from molpy.io.data.top import TopFormatError, TopReader, TopWriter
 
 
 class TestTopReader:
@@ -70,19 +70,95 @@ class TestTopReader:
         assert pytest.approx(float(atom["charge"]), abs=1e-4) == -0.115
         assert pytest.approx(float(atom["mass"]), abs=1e-3) == 12.011
 
-    def test_bond_indices_one_based(self, TEST_DATA_DIR: Path) -> None:
-        """Bond indices should be stored as 1-based integers from file."""
+    def test_bond_indices_are_zero_based_row_indices(self, TEST_DATA_DIR: Path) -> None:
+        """Endpoints are 0-based row indices, not the file's 1-based serials.
+
+        This test previously asserted the opposite (``atomi == 1`` for the
+        record ``1 2 1``), pinning the off-by-one as if it were the contract.
+        """
         top_file = TEST_DATA_DIR / "top/benzene.top"
         if not top_file.exists():
             pytest.skip("benzene.top test data not available")
 
         frame = TopReader(top_file).read()
-        bonds = frame["bonds"]
-        first_bond = bonds[0]
+        first_bond = frame["bonds"][0]
 
-        # First bond in benzene.top: 1 2 1
-        assert int(first_bond["atomi"]) == 1
-        assert int(first_bond["atomj"]) == 2
+        # First bond record in benzene.top is "1 2 1" (serials 1 and 2).
+        assert int(first_bond["atomi"]) == 0
+        assert int(first_bond["atomj"]) == 1
+
+    def test_all_endpoints_index_within_atoms_block(self, TEST_DATA_DIR: Path) -> None:
+        """Every endpoint in every relation block addresses a real atom row.
+
+        Under the old 1-based storage the *last* atom's index equalled
+        ``n_atoms`` and was silently out of range. Benzene's ring bonds do
+        reach atom 12 of 12, so this fails loudly on the unfixed reader.
+        """
+        top_file = TEST_DATA_DIR / "top/benzene.top"
+        if not top_file.exists():
+            pytest.skip("benzene.top test data not available")
+
+        frame = TopReader(top_file).read()
+        n_atoms = frame["atoms"].nrows
+
+        for key in ("bonds", "pairs", "angles", "dihedrals"):
+            if key not in frame:
+                continue
+            block = frame[key]
+            for col in ("atomi", "atomj", "atomk", "atoml"):
+                if col not in block:
+                    continue
+                values = np.asarray(block[col])
+                assert values.min() >= 0, f"{key}.{col} has a negative index"
+                assert values.max() < n_atoms, (
+                    f"{key}.{col} indexes atom {values.max()} but the frame "
+                    f"only has {n_atoms} atoms"
+                )
+
+    def test_endpoint_corpus_touches_first_and_last_atom(
+        self, TEST_DATA_DIR: Path
+    ) -> None:
+        """Meta-test: the fixture must exercise both ends of the index range.
+
+        A 1-based index set is ``[1..N]``, so only the value ``N`` is out of
+        range. Without a record touching the final atom, the test above would
+        pass on the broken reader and prove nothing.
+        """
+        top_file = TEST_DATA_DIR / "top/benzene.top"
+        if not top_file.exists():
+            pytest.skip("benzene.top test data not available")
+
+        frame = TopReader(top_file).read()
+        n_atoms = frame["atoms"].nrows
+        endpoints = np.concatenate(
+            [
+                np.asarray(frame["bonds"][c]).ravel()
+                for c in ("atomi", "atomj")
+                if c in frame["bonds"]
+            ]
+        )
+        assert endpoints.min() == 0, "corpus never references the first atom"
+        assert endpoints.max() == n_atoms - 1, (
+            "corpus never references the last atom, so it cannot detect an "
+            "off-by-one in endpoint indexing"
+        )
+
+    def test_zero_serial_is_rejected_not_dropped(self, tmp_path: Path) -> None:
+        """A 0 serial is invalid GROMACS and must raise, not vanish.
+
+        ``0 - 1 == -1`` would wrap to the last atom; returning ``None`` would
+        silently drop the bond. Both are worse than failing.
+        """
+        top_file = tmp_path / "zero_serial.top"
+        top_file.write_text(
+            "[moleculetype]\nMOL  3\n\n"
+            "[atoms]\n1  CT  1  MOL  C  1  -0.1  12.011\n"
+            "2  HC  1  MOL  H  2  0.1  1.008\n\n"
+            "[bonds]\n0  2  1\n"
+        )
+
+        with pytest.raises(TopFormatError, match="1-based"):
+            TopReader(top_file).read()
 
     def test_read_bromobutane_all_sections(self, TEST_DATA_DIR: Path) -> None:
         """1-bromobutane has atoms, bonds, pairs, angles, and dihedrals."""
@@ -157,23 +233,29 @@ MOL  3
 class TestTopWriter:
     """Tests for TopWriter producing valid GROMACS topology files."""
 
-    def _make_minimal_frame(self) -> molrs.Frame:
-        """Create a minimal two-atom frame with one bond."""
+    def _make_minimal_frame(self, n_atoms: int = 2) -> molrs.Frame:
+        """Create a small frame with one bond between the first two atoms.
+
+        Endpoints are 0-based row indices. The previous fixture used ``atomi=1,
+        atomj=2`` on a two-atom frame — index 2 does not exist, so the fixture
+        itself carried the off-by-one it was meant to test.
+        """
         frame = molrs.Frame()
         frame.meta = {"name": MetaValue("string", "MOL")}
+        idx = np.arange(n_atoms)
         frame["atoms"] = {
-            "id": np.array([1, 2]),
-            "type": np.array(["CT", "HC"]),
-            "resnr": np.array([1, 1]),
-            "residu": np.array(["MOL", "MOL"]),
-            "name": np.array(["C", "H"]),
-            "cgnr": np.array([1, 2]),
-            "charge": np.array([-0.1, 0.1]),
-            "mass": np.array([12.011, 1.008]),
+            "id": idx + 1,
+            "type": np.array(["CT", "HC"] * n_atoms)[:n_atoms],
+            "resnr": np.ones(n_atoms, dtype=int),
+            "residu": np.array(["MOL"] * n_atoms),
+            "name": np.array(["C", "H"] * n_atoms)[:n_atoms],
+            "cgnr": idx + 1,
+            "charge": np.linspace(-0.1, 0.1, n_atoms),
+            "mass": np.array([12.011, 1.008] * n_atoms)[:n_atoms],
         }
         frame["bonds"] = {
-            "atomi": np.array([1]),
-            "atomj": np.array([2]),
+            "atomi": np.array([0]),
+            "atomj": np.array([1]),
             "type": np.array([1]),
         }
         return frame
@@ -236,15 +318,31 @@ class TestTopWriter:
         assert "bonds" in frame2
         assert frame2["bonds"].nrows == 1
         bond = frame2["bonds"][0]
-        assert int(bond["atomi"]) == 1
-        assert int(bond["atomj"]) == 2
+        # Written as GROMACS serials 1/2, read back as row indices 0/1.
+        assert int(bond["atomi"]) == 0
+        assert int(bond["atomj"]) == 1
+
+    def test_writer_emits_one_based_serials(self, tmp_path: Path) -> None:
+        """The [ bonds ] record on disk must carry GROMACS 1-based serials."""
+        frame = self._make_minimal_frame()
+        out_file = tmp_path / "out.top"
+        TopWriter(out_file).write(frame)
+
+        section = out_file.read_text().split("[ bonds ]")[1]
+        record = [
+            ln.strip()
+            for ln in section.splitlines()
+            if ln.strip() and not ln.strip().startswith(";")
+        ][0]
+        # Frame endpoints are rows 0 and 1 → serials 1 and 2 on disk.
+        assert record.split()[:2] == ["1", "2"]
 
     def test_write_pairs_section(self, tmp_path: Path) -> None:
         """TopWriter writes [ pairs ] section when present in frame."""
         frame = self._make_minimal_frame()
         frame["pairs"] = {
-            "atomi": np.array([1]),
-            "atomj": np.array([2]),
+            "atomi": np.array([0]),
+            "atomj": np.array([1]),
             "type": np.array([1]),
         }
         out_file = tmp_path / "out.top"
@@ -255,11 +353,11 @@ class TestTopWriter:
 
     def test_write_angles_section(self, tmp_path: Path) -> None:
         """TopWriter writes [ angles ] section when present in frame."""
-        frame = self._make_minimal_frame()
+        frame = self._make_minimal_frame(n_atoms=3)
         frame["angles"] = {
-            "atomi": np.array([1]),
-            "atomj": np.array([2]),
-            "atomk": np.array([3]),
+            "atomi": np.array([0]),
+            "atomj": np.array([1]),
+            "atomk": np.array([2]),
             "type": np.array([1]),
         }
         out_file = tmp_path / "out.top"
@@ -270,12 +368,12 @@ class TestTopWriter:
 
     def test_write_dihedrals_section(self, tmp_path: Path) -> None:
         """TopWriter writes [ dihedrals ] section when present in frame."""
-        frame = self._make_minimal_frame()
+        frame = self._make_minimal_frame(n_atoms=4)
         frame["dihedrals"] = {
-            "atomi": np.array([1]),
-            "atomj": np.array([2]),
-            "atomk": np.array([3]),
-            "atoml": np.array([4]),
+            "atomi": np.array([0]),
+            "atomj": np.array([1]),
+            "atomk": np.array([2]),
+            "atoml": np.array([3]),
             "type": np.array([1]),
         }
         out_file = tmp_path / "out.top"
@@ -283,6 +381,24 @@ class TestTopWriter:
 
         content = out_file.read_text()
         assert "[ dihedrals ]" in content
+
+    @pytest.mark.parametrize("missing", ["type", "charge", "mass"])
+    def test_write_rejects_missing_forcefield_column(
+        self, tmp_path: Path, missing: str
+    ) -> None:
+        """Force-field data is never fabricated: the write fails instead.
+
+        The writer used to substitute ``type="X"``, ``charge=0.0`` and
+        ``mass=0.0``, producing a topology that loads cleanly and is physically
+        meaningless.
+        """
+        frame = self._make_minimal_frame()
+        atoms = {k: np.asarray(frame["atoms"][k]) for k in frame["atoms"].keys()}
+        del atoms[missing]
+        frame["atoms"] = atoms
+
+        with pytest.raises(ValueError, match=missing):
+            TopWriter(tmp_path / "out.top").write(frame)
 
     def test_write_via_factory(self, tmp_path: Path) -> None:
         """write_top factory function writes topology correctly."""


### PR DESCRIPTION
# Pull Request

## Description

Four independent silent-failure sites where molpy invented values instead of reporting that the file did not supply them. Found while grounding the Frame-schema plan, but each is a real defect **today** and none depends on that work — this is the slice that needs no molrs change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition/improvement

Breaking in the sense that three of these now raise where they previously produced a plausible-looking frame, and `GroReader` no longer emits a `number` column.

## Related Issues

None.

## Changes Made

- **`io/data/top.py` — endpoints were off by one.** GROMACS 1-based atom serials were stored unchanged into the 0-based endpoint columns (`atomi`/`atomj`/`atomk`/`atoml`), shifting every endpoint and putting the last atom out of range. Converted at the parse boundary via `_to_row_index`, mirrored (`+1`) in the writer so round-trips stay stable. A serial `< 1` raises `TopFormatError` — deliberately **not** a `ValueError`, since the line parsers treat `ValueError` as "not a record, skip it" and would have dropped the record silently. Note the sibling force-field reader (`io/forcefield/top.py:242`) already did `int(i) - 1`; the data reader was the outlier.
- **`io/data/top.py` — writer fabricated force-field data.** Dropped the `.get()` defaults substituting `type="X"`, `charge=0.0`, `mass=0.0`; these yield a topology that loads cleanly and is physically meaningless. Missing columns now raise. Positional serials (`nr`, `cgnr`) and the single-`moleculetype` residue fields stay derived — those are format conventions, not measurements.
- **`io/data/lammps.py` — invented masses.** `masses.get(type, 1.0)` silently supplied a mass for any type absent from `Masses`. Now splits the two cases: *no* `Masses` section yields *no* `mass` column (a data file may legitimately leave mass to the input script), while a `Masses` section that omits a type is an inconsistent file and raises.
- **`io/data/lammps.py` — type labels skipped.** The numeric-type → label conversion was nested inside the mass branch, so it was silently skipped whenever masses weren't assigned (e.g. `atom_style="body"`). Label resolution has nothing to do with mass; dedented.
- **`io/data/gro.py` — atom serial mislabelled as atomic number.** Removed `atoms["number"] = atoms["id"]`. Consumers reading `number` as Z saw 1, 2, 3… as hydrogen, helium, lithium. A GRO file carries no element data, so the column is now simply absent.

## Testing

**How has this been tested?**

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

Two existing tests encoded the bugs as contract and were rewritten rather than deleted:

- `test_bond_indices_one_based` asserted `atomi == 1` for the record `1 2 1` — the off-by-one *as the expected result*. Now `test_bond_indices_are_zero_based_row_indices`.
- The `TopWriter` fixtures used endpoints `(1, 2)` on a two-atom frame and `(1, 2, 3, 4)` for angles/dihedrals — i.e. they carried the same out-of-range indices they were meant to guard against.
- `test_gro.py` asserted `int(first_atom["number"]) == 1`, which held only because `number` was a copy of `id`.

New coverage: endpoint-range check across all relation blocks; writer emits 1-based serials; zero-serial rejected rather than dropped; parametrised writer rejection of missing `type`/`charge`/`mass`; LAMMPS missing-`Masses`-entry rejection; GRO `number`-is-not-`id` regression.

One test is load-bearing and worth a look: `test_endpoint_corpus_touches_first_and_last_atom`. A 1-based index set is `[1..N]`, so **only the value `N` is out of range** — without a bond touching the final atom, an endpoint-range test passes on the broken reader and proves nothing. That meta-test asserts the benzene corpus actually has the property.

**Test configuration:**
- Python version: CI `python3.12` (see caveat below)
- Operating System: ubuntu-latest

⚠️ **The suite was not run locally.** `molcrafts-molrs` is not installable in this environment (only `0.0.7` is reachable from the index here, and the local interpreter is 3.11 vs. the project's `>=3.12`), so molpy cannot be imported. What *was* verified locally: `ruff format --check` and `ruff check` clean across `src/` and `tests/`, and a standalone unit test of `_to_row_index` covering the 1→0 mapping, rejection of `0`/`-1`, garbage still raising `ValueError` so line-skipping is preserved, and `TopFormatError` not being a `ValueError` subclass. CI on this PR is the real gate — in particular the tests that pull the external `tests-data` fixtures, which I could not inspect.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Deliberately **not** included, to keep this reviewable and molrs-independent:

- `funct` in `_write_index_section` still defaults to `1` when a relation block has no `type` column. It is the same fabrication class, but frames from other formats carry no GROMACS function selector, and refusing to write them would be a behaviour regression well beyond this fix. Flagged in a code comment; belongs with the `type`/`type_id` split.
- The `number` vs `atomic_number` inconsistency inside molpy is untouched here: `io/forcefield/amber.py:107` already writes the canonical `atomic_number`, while `top.py`, `mol2.py`, `ac.py` and `xyz.py` still write `number`. Converging them changes columns other readers depend on and is better done as one deliberate pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AtzQmhHW9ytphuUdiNuJwt)_